### PR TITLE
Use `refstepcounter` to enable cross-referencing

### DIFF
--- a/zebra-goodies.dtx
+++ b/zebra-goodies.dtx
@@ -486,7 +486,7 @@ This work consists of the file  zebra-goodies.dtx
 %    \begin{macrocode}
 \newcommand{\zebr@note@}[4]{%
   \zebr@marginnote{\textcolor{#2}{\dbend}}%
-  \expandafter\stepcounter{zebr@num@#1}%
+  \expandafter\refstepcounter{zebr@num@#1}%
   \textcolor{#2}{[\colorbox[gray]{0.97}{%
       \textcolor{#2!70!black}{%
         \textsc{\MakeLowercase{\MakeUppercase#1}}


### PR DESCRIPTION
First of all, thanks for the useful package!

Using `\refstepcounter` instead of `\stepcounter` allows cross-referencing comments. Example:

```latex
\documentclass{article}
\usepackage[utf8]{inputenc}
\usepackage{zebra-goodies}
\begin{document}

Test\todo[author1]{\label{todo:one} Here is a todo}

Test\todo[author1]{\label{todo:two} Here is another todo, see also todo \ref{todo:one}}

Test\todo[author1]{\label{todo:three} Yet another todo, see todo's \ref{todo:one}, \ref{todo:two}}

\end{document}
```